### PR TITLE
simple config + fixes + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # ezk
 Enhanced Zookeeper Client
 
-docs: https://godoc.org/github.com/glycerine/ezk
+docs: https://godoc.org/github.com/betable/ezk

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # ezk
 Enhanced Zookeeper Client
+
+docs: https://godoc.org/github.com/glycerine/ezk

--- a/client.go
+++ b/client.go
@@ -320,3 +320,19 @@ func DefaultRetry(op, path string, f func() error) {
 		return err == zk.ErrConnectionClosed || err == zk.ErrSessionExpired || err == zk.ErrSessionMoved
 	}).Execute(f)
 }
+
+// A convenience version of Delete, DeleteNode deletes a znode,
+// using version -1 to delete any version.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
+func (z *Client) DeleteNode(path string) error {
+	return z.Delete(path, -1)
+}
+
+// A convenience version of Create, CreateNode supplies
+// empty data, 0 flags, and the default z.Cfg.Acl list
+// to a z.Create() call.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
+func (z *Client) CreateNode(path string) error {
+	_, err := z.Create(path, []byte{}, 0, z.Cfg.Acl)
+	return err
+}

--- a/client.go
+++ b/client.go
@@ -85,7 +85,8 @@ func (z *Client) Close() {
 	z.Conn.Close()
 }
 
-// Exists checks if a znode exists
+// Exists checks if a znode exists.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) Exists(path string) (ok bool, s *zk.Stat, err error) {
 	path = z.fullpath(path)
 	z.Cfg.Retry("exists", path, func() error {

--- a/client.go
+++ b/client.go
@@ -302,9 +302,8 @@ func (z *Client) fullpath(path string) string {
 	return z.Cfg.Chroot + path
 }
 
-// The DefaultRetry function will retry four
-// times if the first Zookeeper call fails, after sleeping
-//  0ms, 100ms, 500ms and 1500ms.
+// The DefaultRetry function will retry four times if the
+// first Zookeeper call fails, after sleeping in turn: 0ms, 100ms, 500ms and 1500ms.
 func DefaultRetry(op, path string, f func() error) {
 	retry.NewExecutor().
 		WithRetries(4).

--- a/client.go
+++ b/client.go
@@ -1,214 +1,267 @@
+/*
+Package ezk is an enhanced Zookeeper client. It uses the
+connection and underlying operations from
+https://github.com/samuel/go-zookeeper/zk
+in conjunction with automatic retry of operations via the
+https://github.com/betable/retry library.
+*/
 package ezk
 
 import (
-	"strings"
-	"time"
-
+	"fmt"
 	"github.com/betable/retry"
 	"github.com/samuel/go-zookeeper/zk"
+	"time"
 )
 
-// Client is a wrapper over github.com/samuel/go-zookeeper/zk that retries some operations.
+// Client is a wrapper over github.com/samuel/go-zookeeper/zk that retries all but one of its operations according to the ClientConfig.Retry function. The one exception is for CreateProtectedEphemeralSequential(); it is not retried automatically.
 type Client struct {
-	conn   *zk.Conn
-	chroot string
-	acl    []zk.ACL
-	retry  Retry
+
+	// The configuration for the client.
+	Cfg ClientConfig
+
+	// The underlying github.com/samuel/go-zookeeper/zk connection.
+	Conn *zk.Conn
+
+	// WatchCh will be nil until Connect returns without error.
+	// Watches that fire over the Zookeeper connection will be
+	// received on WatchCh.
+	WatchCh <-chan zk.Event
+}
+
+// ClientConfig is used to configure a Client; pass
+// it to NewClient().
+type ClientConfig struct {
+
+	// The Chroot directory will be prepended to all paths
+	Chroot string
+
+	// The set of ACLs used by defeault when
+	// calling Client.Create(), if the formal
+	// parameter acl in Create() is length 0.
+	Acl []zk.ACL
+
+	// The URLs of the zookeepers to attempt to connect to.
+	Servers []string
+
+	// SessionTimeout defaults to 10 seconds if not
+	// otherwise set.
+	SessionTimeout time.Duration
+
+	// The Retry function determines how many times
+	// and how often we retry our Zookeeper operations
+	// before failing. See DefaultRetry() which is
+	// used if this is not otherwise set.
+	Retry Retry
+}
+
+// NewClient creates a new ezk.Client.
+// If the cfg.SessionTimout is set to 0
+// a default value of 10 seconds will be used.
+// If cfg.Retry is nil then the DefaultRetry
+// function will be used.
+// If cfg.Acl is length 0 then zk.WorldACL(zk.PermAll)
+// will be used.
+func NewClient(cfg ClientConfig) *Client {
+	if cfg.Retry == nil {
+		cfg.Retry = DefaultRetry
+	}
+	if cfg.SessionTimeout == 0 {
+		cfg.SessionTimeout = 10 * time.Second
+	}
+	if len(cfg.Acl) == 0 {
+		cfg.Acl = zk.WorldACL(zk.PermAll)
+	}
+	cli := &Client{
+		Cfg: cfg,
+	}
+	return cli
 }
 
 // Retry defines the type of the retry method to use.
 type Retry func(op, path string, f func() error)
 
-type option func(*Client)
-
-// Connect connects to a Zookeeper server. If the sessionTimout is set to 0
-// a default value of 10 seconds will be used.
-//
-// Options can be passed to set a chroot or a default ACL.
-func Connect(servers []string, sessionTimeout time.Duration, opts ...option) (*Client, <-chan zk.Event, error) {
-	if sessionTimeout == 0 {
-		sessionTimeout = 10 * time.Second
-	}
-	conn, ch, err := zk.Connect(servers, sessionTimeout)
+// Connect connects to a Zookeeper server.
+// Upon success it sets the z.WatchCh and
+// z.Conn and returns nil.
+// If an error is returned then z.WatchCh and
+// z.Conn will not be set. Connect() will
+// typically only be needed once, but can be
+// called again if need be.
+// Upon successful connection to Zookeeper,
+// we will attempt to create the z.Cfg.Chroot node.
+// No error will be returned if this attempt
+// fails, as commonly it may already exist.
+func (z *Client) Connect() error {
+	z.WatchCh = nil
+	z.Conn = nil
+	conn, ch, err := zk.Connect(z.Cfg.Servers, z.Cfg.SessionTimeout)
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
+	z.Conn = conn
+	z.WatchCh = ch
 
-	client := &Client{
-		conn:  conn,
-		retry: defaultRetry,
-	}
-
-	client.Options(opts...)
-
-	return client, ch, nil
-}
-
-// ChRoot defines a path that will be prepended to all the operations.
-func ChRoot(root string) option {
-	return func(z *Client) {
-		z.chroot = root
-	}
-}
-
-// DefaultACL defines an ACL that will be used if none is provided.
-func DefaultACL(acl []zk.ACL) option {
-	return func(z *Client) {
-		z.acl = acl
-	}
-}
-
-// SetRetryFunc defines a custom retry function.
-func SetRetryFunc(f Retry) option {
-	return func(z *Client) {
-		z.retry = f
-	}
-}
-
-// Options sets the options in the client.
-func (z *Client) Options(opts ...option) {
-	for _, opt := range opts {
-		opt(z)
-	}
+	// make the Chroot dir; deliberately ignore err as
+	// the Chroot node may already exist.
+	z.Create("", []byte{}, 0, z.Cfg.Acl)
+	return nil
 }
 
 // Close closes the connection to the Zookeeper server.
 func (z *Client) Close() {
-	z.conn.Close()
+	z.Conn.Close()
 }
 
-// Exists returns if a znode exists
+// Exists checks if a znode exists.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) Exists(path string) (ok bool, s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("exists", path, func() error {
-		ok, s, err = z.conn.Exists(path)
+	z.Cfg.Retry("exists", path, func() error {
+		ok, s, err = z.Conn.Exists(path)
 		return err
 	})
 	return ok, s, err
 }
 
 // ExistsW returns if a znode exists and sets a watch.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) ExistsW(path string) (ok bool, s *zk.Stat, ch <-chan zk.Event, err error) {
 	path = z.fullpath(path)
-	z.retry("existsw", path, func() error {
-		ok, s, ch, err = z.conn.ExistsW(path)
+	z.Cfg.Retry("existsw", path, func() error {
+		ok, s, ch, err = z.Conn.ExistsW(path)
 		return err
 	})
 	return ok, s, ch, err
 }
 
-// Create creates a znode with a content.
+// Create creates a znode with a content. If
+// acl is nil then the z.Cfg.Acl set will be
+// applied to the new znode.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) Create(path string, data []byte, flags int32, acl []zk.ACL) (s string, err error) {
 	path = z.fullpath(path)
-	if len(acl) == 0 && len(z.acl) != 0 {
-		acl = z.acl
+	if len(acl) == 0 && len(z.Cfg.Acl) != 0 {
+		acl = z.Cfg.Acl
 	}
-	z.retry("create", path, func() error {
-		s, err = z.conn.Create(path, data, flags, acl)
+	z.Cfg.Retry("create", path, func() error {
+		s, err = z.Conn.Create(path, data, flags, acl)
 		return err
 	})
 	return s, err
 }
 
 // Delete deletes a znode.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) Delete(path string, version int32) (err error) {
 	path = z.fullpath(path)
-	z.retry("delete", path, func() error {
-		err = z.conn.Delete(path, version)
+	z.Cfg.Retry("delete", path, func() error {
+		err = z.Conn.Delete(path, version)
 		return err
 	})
 	return err
 }
 
-// Get returns the contents of a znode
+// Get returns the contents of a znode.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) Get(path string) (d []byte, s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("get", path, func() error {
-		d, s, err = z.conn.Get(path)
+	z.Cfg.Retry("get", path, func() error {
+		d, s, err = z.Conn.Get(path)
 		return err
 	})
 	return d, s, err
 }
 
-// GetW returns the contents of a znode and sets a watch
+// GetW returns the contents of a znode and sets a watch.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) GetW(path string) (d []byte, s *zk.Stat, ch <-chan zk.Event, err error) {
 	path = z.fullpath(path)
-	z.retry("getw", path, func() error {
-		d, s, ch, err = z.conn.GetW(path)
+	z.Cfg.Retry("getw", path, func() error {
+		d, s, ch, err = z.Conn.GetW(path)
 		return err
 	})
 	return d, s, ch, err
 }
 
 // Set writes content in an existent znode.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) Set(path string, data []byte, version int32) (s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("set", path, func() error {
-		s, err = z.conn.Set(path, data, version)
+	z.Cfg.Retry("set", path, func() error {
+		fmt.Printf("Set on path='%s'\n", path)
+		s, err = z.Conn.Set(path, data, version)
 		return err
 	})
 	return s, err
 }
 
 // Children returns the children of a znode.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) Children(path string) (c []string, s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("children", path, func() error {
-		c, s, err = z.conn.Children(path)
+	z.Cfg.Retry("children", path, func() error {
+		c, s, err = z.Conn.Children(path)
 		return err
 	})
 	return c, s, err
 }
 
 // ChildrenW returns the children of a znode and sets a watch.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) ChildrenW(path string) (c []string, s *zk.Stat, ch <-chan zk.Event, err error) {
 	path = z.fullpath(path)
-	z.retry("childrenw", path, func() error {
-		c, s, ch, err = z.conn.ChildrenW(path)
+	z.Cfg.Retry("childrenw", path, func() error {
+		c, s, ch, err = z.Conn.ChildrenW(path)
 		return err
 	})
 	return c, s, ch, err
 }
 
 // Sync performs a sync from the master in the Zookeeper server.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) Sync(path string) (s string, err error) {
 	path = z.fullpath(path)
-	z.retry("sync", path, func() error {
-		s, err = z.conn.Sync(path)
+	z.Cfg.Retry("sync", path, func() error {
+		s, err = z.Conn.Sync(path)
 		return err
 	})
 	return s, err
 }
 
 // GetACL returns the ACL for a znode.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) GetACL(path string) (a []zk.ACL, s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("getacl", path, func() error {
-		a, s, err = z.conn.GetACL(path)
+	z.Cfg.Retry("getacl", path, func() error {
+		a, s, err = z.Conn.GetACL(path)
 		return err
 	})
 	return a, s, err
 }
 
 // SetACL sets a ACL to a znode.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) SetACL(path string, acl []zk.ACL, version int32) (s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("setacl", path, func() error {
-		s, err = z.conn.SetACL(path, acl, version)
+	z.Cfg.Retry("setacl", path, func() error {
+		s, err = z.Conn.SetACL(path, acl, version)
 		return err
 	})
 	return s, err
 }
 
 // CreateProtectedEphemeralSequential creates a sequential ephemeral znode.
+// z.Cfg.Chroot will be prepended to path. The call will be NOT be retried.
 func (z *Client) CreateProtectedEphemeralSequential(path string, data []byte, acl []zk.ACL) (string, error) {
-	// Using the default retry mechanism
 	path = z.fullpath(path)
-	return z.conn.CreateProtectedEphemeralSequential(path, data, acl)
+	return z.Conn.CreateProtectedEphemeralSequential(path, data, acl)
 }
 
 // CreateDir is a helper method that creates and empty znode if it does not exists.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) CreateDir(path string, acl []zk.ACL) error {
+	path = z.fullpath(path)
 	ok, _, err := z.Exists(path)
 	if err != nil {
 		return err
@@ -224,7 +277,8 @@ func (z *Client) CreateDir(path string, acl []zk.ACL) error {
 	return err
 }
 
-// SafeSet is a helper method that writes a znode creating it first if it does not exists.
+// SafeSet is a helper method that writes a znode creating it first if it does not exists. It will sync the Zookeeper before checking if the node exists.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) SafeSet(path string, data []byte, version int32, acl []zk.ACL) (*zk.Stat, error) {
 	_, err := z.Sync(path)
 	if err != nil {
@@ -249,6 +303,7 @@ func (z *Client) SafeSet(path string, data []byte, version int32, acl []zk.ACL) 
 }
 
 // SafeGet is a helper method that syncs Zookeeper and return the content of a znode.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) SafeGet(path string) ([]byte, *zk.Stat, error) {
 	_, err := z.Sync(path)
 	if err != nil {
@@ -258,23 +313,39 @@ func (z *Client) SafeGet(path string) ([]byte, *zk.Stat, error) {
 	return z.Get(path)
 }
 
-// fullpath returns the path with the chroot prepended. It can cause issues
-// if the znode path starts like /foo/foo/...
+// fullpath returns the path with the chroot prepended.
 func (z *Client) fullpath(path string) string {
-	if z.chroot != "" && !strings.HasPrefix(path, z.chroot) {
-		return z.chroot + path
-	}
+	//	if z.Cfg.Chroot != "" && !strings.HasPrefix(path, z.Cfg.Chroot) {
+	//    return z.Cfg.Chroot + path
+	//	}
+	//	return path
 
-	return path
+	return z.Cfg.Chroot + path
 }
 
-func defaultRetry(op, path string, f func() error) {
-	// If the function fails it will retry 4 extra times times
-	// sleeping: 0ms, 100ms, 500ms and 1500ms
+// The DefaultRetry function will retry four times if the
+// first Zookeeper call fails, after sleeping in turn: 0ms, 100ms, 500ms and 1500ms.
+func DefaultRetry(op, path string, f func() error) {
 	retry.NewExecutor().
 		WithRetries(4).
 		WithBackoff(retry.ExponentialDelayBackoff(100*time.Millisecond, 5)).
 		WithErrorComparator(func(err error) bool {
 		return err == zk.ErrConnectionClosed || err == zk.ErrSessionExpired || err == zk.ErrSessionMoved
 	}).Execute(f)
+}
+
+// A convenience version of Delete, DeleteNode deletes a znode,
+// using version -1 to delete any version.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
+func (z *Client) DeleteNode(path string) error {
+	return z.Delete(path, -1)
+}
+
+// A convenience version of Create, CreateNode supplies
+// empty data, 0 flags, and the default z.Cfg.Acl list
+// to a z.Create() call.
+// z.Cfg.Chroot will be prepended to path. The call will be retried.
+func (z *Client) CreateNode(path string) error {
+	_, err := z.Create(path, []byte{}, 0, z.Cfg.Acl)
+	return err
 }

--- a/client.go
+++ b/client.go
@@ -16,6 +16,8 @@ type Client struct {
 	Conn *zk.Conn
 
 	// WatchCh will be nil until Connect returns without error.
+	// Watches that fire over the Zookeeper connection will be
+	// received on WatchCh.
 	WatchCh <-chan zk.Event
 }
 

--- a/client.go
+++ b/client.go
@@ -262,7 +262,7 @@ func (z *Client) CreateDir(path string, acl []zk.ACL) error {
 	return err
 }
 
-// SafeSet is a helper method that writes a znode creating it first if it does not exists.
+// SafeSet is a helper method that writes a znode creating it first if it does not exists. It will sync the Zookeeper before checking if the node exists.
 // z.Cfg.Chroot will be prepended to path. The call will be retried.
 func (z *Client) SafeSet(path string, data []byte, version int32, acl []zk.ACL) (*zk.Stat, error) {
 	path = z.fullpath(path)

--- a/client.go
+++ b/client.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// Client is a wrapper over github.com/samuel/go-zookeeper/zk that retries some operations.
+// Client is a wrapper over github.com/samuel/go-zookeeper/zk that retries all but one of its operations according to the ClientConfig.Retry function. The one exception is for CreateProtectedEphemeralSequential(); it is not retried automatically.
 type Client struct {
 
 	// The configuration for the client.

--- a/client.go
+++ b/client.go
@@ -50,7 +50,7 @@ type ClientConfig struct {
 // NewClient creates a new ezk.Client.
 // If the cfg.SessionTimout is set to 0
 // a default value of 10 seconds will be used.
-// If cfg.Retry is nil then the zk.defaultRetry
+// If cfg.Retry is nil then the DefaultRetry
 // function will be used.
 func NewClient(cfg ClientConfig) *Client {
 	if cfg.Retry == nil {

--- a/client.go
+++ b/client.go
@@ -88,6 +88,10 @@ type Retry func(op, path string, f func() error)
 // z.Conn will not be set. Connect() will
 // typically only be needed once, but can be
 // called again if need be.
+// Upon successful connection to Zookeeper,
+// we will attempt to create the z.Cfg.Chroot node.
+// No error will be returned if this attempt
+// fails, as commonly it may already exist.
 func (z *Client) Connect() error {
 	z.WatchCh = nil
 	z.Conn = nil

--- a/client.go
+++ b/client.go
@@ -30,11 +30,27 @@ type Client struct {
 // ClientConfig is used to configure a Client; pass
 // it to NewClient().
 type ClientConfig struct {
-	Chroot         string
-	Acl            []zk.ACL
-	Servers        []string
+
+	// The Chroot directory will be prepended to all paths
+	Chroot string
+
+	// The set of ACLs used by defeault when
+	// calling Client.Create(), if the formal
+	// parameter acl in Create() is length 0.
+	Acl []zk.ACL
+
+	// The URLs of the zookeepers to attempt to connect to.
+	Servers []string
+
+	// SessionTimeout defaults to 10 seconds if not
+	// otherwise set.
 	SessionTimeout time.Duration
-	Retry          Retry
+
+	// The retry function determines how many times
+	// and how often we retry our Zookeeper operations
+	// before failing. See DefaultRetry() which is
+	// used if this is not otherwise set.
+	Retry Retry
 }
 
 // NewClient creates a new ezk.Client.
@@ -99,7 +115,9 @@ func (z *Client) ExistsW(path string) (ok bool, s *zk.Stat, ch <-chan zk.Event, 
 	return ok, s, ch, err
 }
 
-// Create creates a znode with a content.
+// Create creates a znode with a content. If
+// acl is nil then the z.Cfg.Acl set will be
+// applied to the new znode.
 func (z *Client) Create(path string, data []byte, flags int32, acl []zk.ACL) (s string, err error) {
 	path = z.fullpath(path)
 	if len(acl) == 0 && len(z.Cfg.Acl) != 0 {

--- a/client.go
+++ b/client.go
@@ -1,87 +1,89 @@
 package ezk
 
 import (
-	"strings"
-	"time"
-
+	"fmt"
 	"github.com/betable/retry"
 	"github.com/samuel/go-zookeeper/zk"
+	"time"
 )
 
 // Client is a wrapper over github.com/samuel/go-zookeeper/zk that retries some operations.
 type Client struct {
-	conn   *zk.Conn
-	chroot string
-	acl    []zk.ACL
-	retry  Retry
+
+	// The configuration for the client.
+	Cfg ClientConfig
+
+	// The underlying github.com/samuel/go-zookeeper/zk connection.
+	Conn *zk.Conn
+
+	// WatchCh will be nil until Ready is indicated
+	// by being closed.
+	WatchCh <-chan zk.Event
+
+	// Ready is closed when the Zookeeper connection
+	// is first made. After that you WatchCh will
+	// no longer be nil and Watch events may
+	// be received.
+	Ready chan bool
+}
+
+// ClientConfig is used to configure a Client; pass
+// it to NewClient().
+type ClientConfig struct {
+	Chroot         string
+	Acl            []zk.ACL
+	Servers        []string
+	SessionTimeout time.Duration
+	Retry          Retry
+}
+
+// NewClient creates a new ezk.Client.
+// If the cfg.SessionTimout is set to 0
+// a default value of 10 seconds will be used.
+// If cfg.Retry is nil then the zk.defaultRetry
+// function will be used.
+func NewClient(cfg ClientConfig) *Client {
+	if cfg.Retry == nil {
+		fmt.Printf("cfg.Retry was nil, setting DefaultRetry\n")
+		cfg.Retry = DefaultRetry
+	}
+	if cfg.SessionTimeout == 0 {
+		cfg.SessionTimeout = 10 * time.Second
+	}
+	cli := &Client{
+		Cfg:   cfg,
+		Ready: make(chan bool),
+	}
+	return cli
 }
 
 // Retry defines the type of the retry method to use.
 type Retry func(op, path string, f func() error)
 
-type option func(*Client)
-
-// Connect connects to a Zookeeper server. If the sessionTimout is set to 0
-// a default value of 10 seconds will be used.
+// Connect connects to a Zookeeper server.
 //
 // Options can be passed to set a chroot or a default ACL.
-func Connect(servers []string, sessionTimeout time.Duration, opts ...option) (*Client, <-chan zk.Event, error) {
-	if sessionTimeout == 0 {
-		sessionTimeout = 10 * time.Second
-	}
-	conn, ch, err := zk.Connect(servers, sessionTimeout)
+func (z *Client) Connect() error {
+	conn, ch, err := zk.Connect(z.Cfg.Servers, z.Cfg.SessionTimeout)
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
-
-	client := &Client{
-		conn:  conn,
-		retry: defaultRetry,
-	}
-
-	client.Options(opts...)
-
-	return client, ch, nil
-}
-
-// ChRoot defines a path that will be prepended to all the operations.
-func ChRoot(root string) option {
-	return func(z *Client) {
-		z.chroot = root
-	}
-}
-
-// DefaultACL defines an ACL that will be used if none is provided.
-func DefaultACL(acl []zk.ACL) option {
-	return func(z *Client) {
-		z.acl = acl
-	}
-}
-
-// SetRetryFunc defines a custom retry function.
-func SetRetryFunc(f Retry) option {
-	return func(z *Client) {
-		z.retry = f
-	}
-}
-
-// Options sets the options in the client.
-func (z *Client) Options(opts ...option) {
-	for _, opt := range opts {
-		opt(z)
-	}
+	z.Conn = conn
+	z.WatchCh = ch
+	close(z.Ready)
+	return nil
 }
 
 // Close closes the connection to the Zookeeper server.
 func (z *Client) Close() {
-	z.conn.Close()
+	z.Conn.Close()
 }
 
-// Exists returns if a znode exists
+// Exists checks if a znode exists
 func (z *Client) Exists(path string) (ok bool, s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("exists", path, func() error {
-		ok, s, err = z.conn.Exists(path)
+	z.Cfg.Retry("exists", path, func() error {
+		ok, s, err = z.Conn.Exists(path)
 		return err
 	})
 	return ok, s, err
@@ -90,8 +92,8 @@ func (z *Client) Exists(path string) (ok bool, s *zk.Stat, err error) {
 // ExistsW returns if a znode exists and sets a watch.
 func (z *Client) ExistsW(path string) (ok bool, s *zk.Stat, ch <-chan zk.Event, err error) {
 	path = z.fullpath(path)
-	z.retry("existsw", path, func() error {
-		ok, s, ch, err = z.conn.ExistsW(path)
+	z.Cfg.Retry("existsw", path, func() error {
+		ok, s, ch, err = z.Conn.ExistsW(path)
 		return err
 	})
 	return ok, s, ch, err
@@ -100,11 +102,11 @@ func (z *Client) ExistsW(path string) (ok bool, s *zk.Stat, ch <-chan zk.Event, 
 // Create creates a znode with a content.
 func (z *Client) Create(path string, data []byte, flags int32, acl []zk.ACL) (s string, err error) {
 	path = z.fullpath(path)
-	if len(acl) == 0 && len(z.acl) != 0 {
-		acl = z.acl
+	if len(acl) == 0 && len(z.Cfg.Acl) != 0 {
+		acl = z.Cfg.Acl
 	}
-	z.retry("create", path, func() error {
-		s, err = z.conn.Create(path, data, flags, acl)
+	z.Cfg.Retry("create", path, func() error {
+		s, err = z.Conn.Create(path, data, flags, acl)
 		return err
 	})
 	return s, err
@@ -113,8 +115,8 @@ func (z *Client) Create(path string, data []byte, flags int32, acl []zk.ACL) (s 
 // Delete deletes a znode.
 func (z *Client) Delete(path string, version int32) (err error) {
 	path = z.fullpath(path)
-	z.retry("delete", path, func() error {
-		err = z.conn.Delete(path, version)
+	z.Cfg.Retry("delete", path, func() error {
+		err = z.Conn.Delete(path, version)
 		return err
 	})
 	return err
@@ -123,8 +125,8 @@ func (z *Client) Delete(path string, version int32) (err error) {
 // Get returns the contents of a znode
 func (z *Client) Get(path string) (d []byte, s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("get", path, func() error {
-		d, s, err = z.conn.Get(path)
+	z.Cfg.Retry("get", path, func() error {
+		d, s, err = z.Conn.Get(path)
 		return err
 	})
 	return d, s, err
@@ -133,8 +135,8 @@ func (z *Client) Get(path string) (d []byte, s *zk.Stat, err error) {
 // GetW returns the contents of a znode and sets a watch
 func (z *Client) GetW(path string) (d []byte, s *zk.Stat, ch <-chan zk.Event, err error) {
 	path = z.fullpath(path)
-	z.retry("getw", path, func() error {
-		d, s, ch, err = z.conn.GetW(path)
+	z.Cfg.Retry("getw", path, func() error {
+		d, s, ch, err = z.Conn.GetW(path)
 		return err
 	})
 	return d, s, ch, err
@@ -143,8 +145,8 @@ func (z *Client) GetW(path string) (d []byte, s *zk.Stat, ch <-chan zk.Event, er
 // Set writes content in an existent znode.
 func (z *Client) Set(path string, data []byte, version int32) (s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("set", path, func() error {
-		s, err = z.conn.Set(path, data, version)
+	z.Cfg.Retry("set", path, func() error {
+		s, err = z.Conn.Set(path, data, version)
 		return err
 	})
 	return s, err
@@ -153,8 +155,8 @@ func (z *Client) Set(path string, data []byte, version int32) (s *zk.Stat, err e
 // Children returns the children of a znode.
 func (z *Client) Children(path string) (c []string, s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("children", path, func() error {
-		c, s, err = z.conn.Children(path)
+	z.Cfg.Retry("children", path, func() error {
+		c, s, err = z.Conn.Children(path)
 		return err
 	})
 	return c, s, err
@@ -163,8 +165,8 @@ func (z *Client) Children(path string) (c []string, s *zk.Stat, err error) {
 // ChildrenW returns the children of a znode and sets a watch.
 func (z *Client) ChildrenW(path string) (c []string, s *zk.Stat, ch <-chan zk.Event, err error) {
 	path = z.fullpath(path)
-	z.retry("childrenw", path, func() error {
-		c, s, ch, err = z.conn.ChildrenW(path)
+	z.Cfg.Retry("childrenw", path, func() error {
+		c, s, ch, err = z.Conn.ChildrenW(path)
 		return err
 	})
 	return c, s, ch, err
@@ -173,8 +175,8 @@ func (z *Client) ChildrenW(path string) (c []string, s *zk.Stat, ch <-chan zk.Ev
 // Sync performs a sync from the master in the Zookeeper server.
 func (z *Client) Sync(path string) (s string, err error) {
 	path = z.fullpath(path)
-	z.retry("sync", path, func() error {
-		s, err = z.conn.Sync(path)
+	z.Cfg.Retry("sync", path, func() error {
+		s, err = z.Conn.Sync(path)
 		return err
 	})
 	return s, err
@@ -183,8 +185,8 @@ func (z *Client) Sync(path string) (s string, err error) {
 // GetACL returns the ACL for a znode.
 func (z *Client) GetACL(path string) (a []zk.ACL, s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("getacl", path, func() error {
-		a, s, err = z.conn.GetACL(path)
+	z.Cfg.Retry("getacl", path, func() error {
+		a, s, err = z.Conn.GetACL(path)
 		return err
 	})
 	return a, s, err
@@ -193,8 +195,8 @@ func (z *Client) GetACL(path string) (a []zk.ACL, s *zk.Stat, err error) {
 // SetACL sets a ACL to a znode.
 func (z *Client) SetACL(path string, acl []zk.ACL, version int32) (s *zk.Stat, err error) {
 	path = z.fullpath(path)
-	z.retry("setacl", path, func() error {
-		s, err = z.conn.SetACL(path, acl, version)
+	z.Cfg.Retry("setacl", path, func() error {
+		s, err = z.Conn.SetACL(path, acl, version)
 		return err
 	})
 	return s, err
@@ -202,13 +204,13 @@ func (z *Client) SetACL(path string, acl []zk.ACL, version int32) (s *zk.Stat, e
 
 // CreateProtectedEphemeralSequential creates a sequential ephemeral znode.
 func (z *Client) CreateProtectedEphemeralSequential(path string, data []byte, acl []zk.ACL) (string, error) {
-	// Using the default retry mechanism
 	path = z.fullpath(path)
-	return z.conn.CreateProtectedEphemeralSequential(path, data, acl)
+	return z.Conn.CreateProtectedEphemeralSequential(path, data, acl)
 }
 
 // CreateDir is a helper method that creates and empty znode if it does not exists.
 func (z *Client) CreateDir(path string, acl []zk.ACL) error {
+	path = z.fullpath(path)
 	ok, _, err := z.Exists(path)
 	if err != nil {
 		return err
@@ -226,6 +228,7 @@ func (z *Client) CreateDir(path string, acl []zk.ACL) error {
 
 // SafeSet is a helper method that writes a znode creating it first if it does not exists.
 func (z *Client) SafeSet(path string, data []byte, version int32, acl []zk.ACL) (*zk.Stat, error) {
+	path = z.fullpath(path)
 	_, err := z.Sync(path)
 	if err != nil {
 		return nil, err
@@ -250,6 +253,7 @@ func (z *Client) SafeSet(path string, data []byte, version int32, acl []zk.ACL) 
 
 // SafeGet is a helper method that syncs Zookeeper and return the content of a znode.
 func (z *Client) SafeGet(path string) ([]byte, *zk.Stat, error) {
+	path = z.fullpath(path)
 	_, err := z.Sync(path)
 	if err != nil {
 		return nil, nil, err
@@ -261,16 +265,18 @@ func (z *Client) SafeGet(path string) ([]byte, *zk.Stat, error) {
 // fullpath returns the path with the chroot prepended. It can cause issues
 // if the znode path starts like /foo/foo/...
 func (z *Client) fullpath(path string) string {
-	if z.chroot != "" && !strings.HasPrefix(path, z.chroot) {
-		return z.chroot + path
-	}
+	//	if z.Cfg.Chroot != "" && !strings.HasPrefix(path, z.Cfg.Chroot) {
+	//    return z.Cfg.Chroot + path
+	//	}
+	//	return path
 
-	return path
+	return z.Cfg.Chroot + path
 }
 
-func defaultRetry(op, path string, f func() error) {
-	// If the function fails it will retry 4 extra times times
-	// sleeping: 0ms, 100ms, 500ms and 1500ms
+// The DefaultRetry function will retry four
+// times if the first Zookeeper call fails, after sleeping
+//  0ms, 100ms, 500ms and 1500ms.
+func DefaultRetry(op, path string, f func() error) {
 	retry.NewExecutor().
 		WithRetries(4).
 		WithBackoff(retry.ExponentialDelayBackoff(100*time.Millisecond, 5)).

--- a/client.go
+++ b/client.go
@@ -76,8 +76,15 @@ func NewClient(cfg ClientConfig) *Client {
 type Retry func(op, path string, f func() error)
 
 // Connect connects to a Zookeeper server.
-// Upon success it sets the z.WatchCh and returns nil.
+// Upon success it sets the z.WatchCh and
+// z.Conn and returns nil.
+// If an error is returned then z.WatchCh and
+// z.Conn will not be set. Connect() will
+// typically only be needed once, but can be
+// called again if need be.
 func (z *Client) Connect() error {
+	z.WatchCh = nil
+	z.Conn = nil
 	conn, ch, err := zk.Connect(z.Cfg.Servers, z.Cfg.SessionTimeout)
 	if err != nil {
 		return err

--- a/client.go
+++ b/client.go
@@ -1,3 +1,10 @@
+/*
+Package ezk is an enhanced Zookeeper client. It uses the
+connection and underlying operations from
+https://github.com/samuel/go-zookeeper/zk
+in conjunction with automatic retry of operations via the
+https://github.com/betable/retry library.
+*/
 package ezk
 
 import (

--- a/client.go
+++ b/client.go
@@ -47,7 +47,7 @@ type ClientConfig struct {
 	// otherwise set.
 	SessionTimeout time.Duration
 
-	// The retry function determines how many times
+	// The Retry function determines how many times
 	// and how often we retry our Zookeeper operations
 	// before failing. See DefaultRetry() which is
 	// used if this is not otherwise set.

--- a/client_test.go
+++ b/client_test.go
@@ -16,9 +16,9 @@ func Test001ClientRetryGetsDefault(t *testing.T) {
 	})
 }
 
-// In the Connect example, the goal is to set
+// In the example code, the goal is to set
 // the value newURL into the node /chroot/service-name/config/server-url-list
-func ExampleConnect() {
+func Example() {
 	newURL := "http://my-new-url.org:343/hello/enhanced-zookeeper-client"
 
 	base := "/chroot"

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,60 @@
+package ezk
+
+import (
+	cv "github.com/glycerine/goconvey/convey"
+	zook "github.com/samuel/go-zookeeper/zk"
+	"testing"
+	"time"
+)
+
+func Test001ClientRetryGetsDefault(t *testing.T) {
+	cv.Convey("Given that we don't configure a Retry function, we should get the DefaultRetry function in our ClientConfig", t, func() {
+
+		cli := NewClient(ClientConfig{})
+		cv.So(cli.Cfg.Retry, cv.ShouldEqual, DefaultRetry)
+
+	})
+}
+
+// In the example code, the goal is to set
+// the value newURL into the node /chroot/service-name/config/server-url-list
+func ExampleClient() {
+	newURL := "http://my-new-url.org:343/hello/enhanced-zookeeper-client"
+
+	base := "/chroot"
+	nsTest := "/service-name"
+	subdir := "/config"
+	path := nsTest + subdir + "/server-url-list"
+	zkCfg := ClientConfig{
+		Servers:        []string{"127.0.0.1:2181"},
+		Acl:            zook.WorldACL(zook.PermAll),
+		Chroot:         base,
+		SessionTimeout: 10 * time.Second,
+	}
+	zk := NewClient(zkCfg)
+	err := zk.Connect()
+	if err != nil {
+		panic(err)
+	}
+
+	defer zk.Close()
+
+	zk.CreateNode(nsTest)
+	zk.CreateNode(nsTest + subdir)
+	zk.CreateNode(path)
+
+	err = zk.DeleteNode(path) // delete any old value
+	if err != nil {
+		panic(err)
+	}
+
+	err = zk.CreateNode(path)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = zk.Set(path, []byte(newURL), -1)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -18,7 +18,7 @@ func Test001ClientRetryGetsDefault(t *testing.T) {
 
 // In the example code, the goal is to set
 // the value newURL into the node /chroot/service-name/config/server-url-list
-func Example() {
+func ExampleClient() {
 	newURL := "http://my-new-url.org:343/hello/enhanced-zookeeper-client"
 
 	base := "/chroot"

--- a/client_test.go
+++ b/client_test.go
@@ -2,7 +2,9 @@ package ezk
 
 import (
 	cv "github.com/glycerine/goconvey/convey"
+	zook "github.com/samuel/go-zookeeper/zk"
 	"testing"
+	"time"
 )
 
 func Test001ClientRetryGetsDefault(t *testing.T) {
@@ -12,4 +14,47 @@ func Test001ClientRetryGetsDefault(t *testing.T) {
 		cv.So(cli.Cfg.Retry, cv.ShouldEqual, DefaultRetry)
 
 	})
+}
+
+// In the Connect example, the goal is to set
+// the value newURL into the node /chroot/service-name/config/server-url-list
+func ExampleConnect() {
+	newURL := "http://my-new-url.org:343/hello/enhanced-zookeeper-client"
+
+	base := "/chroot"
+	nsTest := "/service-name"
+	subdir := "/config"
+	path := nsTest + subdir + "/server-url-list"
+	zkCfg := ClientConfig{
+		Servers:        []string{"127.0.0.1:2181"},
+		Acl:            zook.WorldACL(zook.PermAll),
+		Chroot:         base,
+		SessionTimeout: 10 * time.Second,
+	}
+	zk := NewClient(zkCfg)
+	err := zk.Connect()
+	if err != nil {
+		panic(err)
+	}
+
+	defer zk.Close()
+
+	zk.CreateNode(nsTest)
+	zk.CreateNode(nsTest + subdir)
+	zk.CreateNode(path)
+
+	err = zk.DeleteNode(path) // delete any old value
+	if err != nil {
+		panic(err)
+	}
+
+	err = zk.CreateNode(path)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = zk.Set(path, []byte(newURL), -1)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,15 @@
+package ezk
+
+import (
+	cv "github.com/glycerine/goconvey/convey"
+	"testing"
+)
+
+func Test001ClientRetryGetsDefault(t *testing.T) {
+	cv.Convey("Given that we don't configure a Retry function, we should get the DefaultRetry function in our ClientConfig", t, func() {
+
+		cli := NewClient(ClientConfig{})
+		cv.So(cli.Cfg.Retry, cv.ShouldEqual, DefaultRetry)
+
+	})
+}


### PR DESCRIPTION
This PR adds several methods, adds much documentation, and fixes the Chroot chicken and egg problem by creating it upon Connect; it does assume that Chroot is a single node and not a multiple element path.

docs are view-able here https://godoc.org/github.com/glycerine/ezk

I took the special case out of fullpath(); hopefully it be kept that simple; but I admit I didn't fully grok where it was needed.
